### PR TITLE
fix(bower):  fix invalid-meta minified files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-schema-form-ckeditor",
   "main": [
-    "bootstrap-ckeditor.min.js"
+    "bootstrap-ckeditor.js"
   ],
   "version": "0.0.1",
   "authors": [


### PR DESCRIPTION
The main field of the bower.json file should not contain minified files according to bower spec.

Fix #3 